### PR TITLE
rewritelocalizecalls now has an option to output keyvalue pair json file

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -751,3 +751,34 @@ export function createLocalizedMessages(filename: string, bundle: ResolvedJavaSc
 		return { messages: PackageJsonMessageBundle.asTranslatedMessages(bundle, messages, problems), problems };
 	}
 }
+
+export function bundle2kvp(bundle: JavaScriptMessageBundle): any{
+	let kvpObject = {};
+	
+	for(var i=0; i < bundle.messages.length; ++i) {
+		let key: string;
+		let comments: string[];
+		let message: string = bundle.messages[i];
+		let isLocalizeInfo: boolean = LocalizeInfo.is(bundle.keys[i]);
+		
+		if (isLocalizeInfo) {
+			key = (<LocalizeInfo>bundle.keys[i]).key;
+			comments = (<LocalizeInfo>bundle.keys[i]).comment;
+		} else {
+			key = <string>bundle.keys[i];
+		}
+		
+		if(key in kvpObject)
+		{
+			throw new Error("The following key is duplicated: \"" + key + "\". Please use unique keys.");
+		}
+		
+		kvpObject[key] = bundle.messages[i];
+		
+		if (isLocalizeInfo) {
+			kvpObject["_"+key+".comment"] = comments.join(' ');
+		}
+	}
+	
+	return kvpObject;
+}

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -52,6 +52,13 @@ export interface LocalizeInfo {
 	comment: string[];
 }
 
+export namespace LocalizeInfo {
+	export function is(value: any): value is JavaScriptMessageBundle {
+		let candidate = value as LocalizeInfo;
+		return candidate && isDefined(candidate.key) && isDefined(candidate.comment);
+	}
+}
+
 export type KeyInfo = string | LocalizeInfo;
 
 export interface JavaScriptMessageBundle {


### PR DESCRIPTION
I modified rewritelocalizecalls() to take a Boolean that specifies whether or not to output a key-value pair json file. This is a nonbreaking change that would really help make localization a lot easier for my team.