### PR TITLE
Making problem logging optional

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -87,7 +87,7 @@ const iso639_3_to_2 = {
 
 export const coreLanguages: string[] = ['chs', 'cht', 'jpn', 'kor', 'deu', 'fra', 'esn', 'rus', 'ita'];
 
-export function createAdditionalLanguageFiles(languages: string[], i18nBaseDir: string, baseDir?: string): ThroughStream {
+export function createAdditionalLanguageFiles(languages: string[], i18nBaseDir: string, baseDir?: string, logProblems: boolean = true): ThroughStream {
 	return through(function(file: File) {
 		let basename = path.basename(file.relative);
 		if (basename.length < NLS_JSON.length || NLS_JSON !== basename.substr(basename.length - NLS_JSON.length)) {
@@ -102,7 +102,7 @@ export function createAdditionalLanguageFiles(languages: string[], i18nBaseDir: 
 			let resolvedBundle = resolveMessageBundle(json);
 			languages.forEach((language) => {
 				let result = createLocalizedMessages(filename, resolvedBundle, language, i18nBaseDir, baseDir);
-				if (result.problems && result.problems.length > 0) {
+				if (result.problems && result.problems.length > 0 && logProblems) {
 					result.problems.forEach(problem => log(problem));
 				}
 				if (result.messages) {


### PR DESCRIPTION
Hello! I am part of the [vscode-mssql team](https://github.com/Microsoft/vscode-mssql). 
We had an issue ignoring the problem logs (which exist because our entire extension is not translated yet) and Gulp does not have functionality to filter certain logs. 

I added an optional toggle for the problem logs. The default it set to true (print the problems as usual).

We are currently depending on this fork on my account, but it would be awesome to include this in your next release so we can depend on the official vscode-nls-dev.