### PR TITLE
Set newline to LF for Linux/mac

### DIFF
--- a/src/tsconfig.json
+++ b/src/tsconfig.json
@@ -11,6 +11,7 @@
 		"inlineSources": false,
 		"declaration": true,
 		"stripInternal": true,
-		"outDir": "../lib"
+		"outDir": "../lib",
+		"newLine": "LF"
 	}
 }


### PR DESCRIPTION
Currently 'vscl' command does not work on mac and Linux
because vscl.js's shebang has **CR**LF newline code:

```
$ $(npm bin)/vscl
/usr/bin/env: `node\r': No such file or directory
```

This patch changes newline into LF. This works on all platforms of VSCode (mac, Linux and Windows)