### PR TITLE
Bundler friendly filenames

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -347,7 +347,7 @@ class TextModel {
 	}
 }
 
-function analyze(contents: string, options: ts.CompilerOptions = {}): AnalysisResult {
+function analyze(contents: string, relativeFilename: string, options: ts.CompilerOptions = {}): AnalysisResult {
 
 	const vscodeRegExp = /^\s*(["'])vscode-nls\1\s*$/;
 
@@ -555,7 +555,7 @@ function analyze(contents: string, options: ts.CompilerOptions = {}): AnalysisRe
 			let args = loadCall.arguments;
 			patches.push({
 				span: { start: ts.getLineAndCharacterOfPosition(sourceFile, args.pos), end: ts.getLineAndCharacterOfPosition(sourceFile, args.end) },
-				content: '__filename',
+				content: relativeFilename ? `require('path').join(__dirname, '${relativeFilename}')` : '__filename',
 			});
 		}
 		return memo;
@@ -640,9 +640,9 @@ function analyze(contents: string, options: ts.CompilerOptions = {}): AnalysisRe
 	};
 }
 
-export function processFile(contents: string, sourceMap?: string | RawSourceMap): { contents: string, sourceMap: string, bundle: JavaScriptMessageBundle, errors: string[] } {
+export function processFile(contents: string, relativeFileName: string, sourceMap?: string | RawSourceMap): { contents: string, sourceMap: string, bundle: JavaScriptMessageBundle, errors: string[] } {
 
-	const analysisResult = analyze(contents);
+	const analysisResult = analyze(contents, relativeFileName);
 	if (analysisResult.patches.length === 0) {
 		return {
 			contents: undefined,

--- a/src/main.ts
+++ b/src/main.ts
@@ -77,7 +77,7 @@ function removePathPrefix(path: string, prefix: string): string {
 	}
 }
 
-export function rewriteLocalizeCalls(): ThroughStream {
+export function rewriteLocalizeCalls(opts: { keepFilenames?: boolean } = {}): ThroughStream {
 	return through(
 		function (this: ThroughStream, file: FileWithSourceMap) {
 			if (!file.isBuffer()) {
@@ -88,7 +88,7 @@ export function rewriteLocalizeCalls(): ThroughStream {
 			let content = buffer.toString('utf8');
 			let sourceMap = file.sourceMap;
 
-			let result = processFile(content, sourceMap);
+			let result = processFile(content, opts.keepFilenames && file.relative, sourceMap);
 			let messagesFile: File;
 			let metaDataFile: File;
 			if (result.errors && result.errors.length > 0) {

--- a/src/tests/analyze.tests.ts
+++ b/src/tests/analyze.tests.ts
@@ -23,7 +23,7 @@ describe('Localize', () => {
 			"localize(0, null, 'Hello', 'World');",
 			"//# sourceMappingURL=test.js.map"
 		];
-		let result = nlsDev.processFile(code.join('\r\n'), sourceMap);
+		let result = nlsDev.processFile(code.join('\r\n'), undefined, sourceMap);
 
 		assert.strictEqual(result.contents, expected.join('\r\n'));
 		assert.strictEqual(result.sourceMap, '{"version":3,"sources":["test.ts"],"names":[],"mappings":"AAAA,IAAY,GAAG,WAAM,YAAY,CAAC,CAAA;AAClC,IAAI,QAAQ,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,MAAM,EAAE,OAAO,EAAE,KAAK,EAAE,IAAI,EAAE,CAAC,YAAE,CAAC;AAC9D,QAAQ,CAAC,aAAyB,EAAE,OAAO,CAAC,CAAC","sourceRoot":""}');
@@ -53,7 +53,7 @@ describe('Localize', () => {
 			"localize(0, null, 'Hello', 'World');",
 			"//# sourceMappingURL=test.js.map"
 		];
-		let result = nlsDev.processFile(code.join('\r\n'), sourceMap);
+		let result = nlsDev.processFile(code.join('\r\n'), undefined, sourceMap);
 		assert.strictEqual(result.contents, expected.join('\r\n'));
 		assert.strictEqual(result.sourceMap, '{"version":3,"sources":["test.ts"],"names":[],"mappings":"AAAA,IAAY,GAAG,WAAM,YAAY,CAAC,CAAA;AAClC,IAAI,QAAQ,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,MAAM,EAAE,OAAO,EAAE,KAAK,EAAE,IAAI,EAAE,CAAC,YAAE,CAAC;AAC9D,QAAQ,CAAC,CAGR,EAAE,IAAS,EAAE,OAAO,EAAE,OAAO,CAAC,CAAC","sourceRoot":""}');
 		assert.deepStrictEqual(result.bundle, {
@@ -74,10 +74,25 @@ describe('Localize', () => {
 			"var localize = nls.loadMessageBundle();",
 			"localize('keyOne', '{0} {1}', 'Hello', 'World');"
 		];
-		let result = nlsDev.processFile(code.join('\n'));
+		let result = nlsDev.processFile(code.join('\n'), undefined);
 		let expected: string[] = [
 			"var nls = require('vscode-nls');",
 			"var localize = nls.loadMessageBundle(__filename);",
+			"localize(0, null, 'Hello', 'World');"
+		];
+		assert.strictEqual(result.contents, expected.join('\n'));
+	})
+
+	it('keepFilename', () => {
+		let code: string[] = [
+			"var nls = require('vscode-nls');",
+			"var localize = nls.loadMessageBundle();",
+			"localize('keyOne', '{0} {1}', 'Hello', 'World');"
+		];
+		let result = nlsDev.processFile(code.join('\n'), 'foo.js');
+		let expected: string[] = [
+			"var nls = require('vscode-nls');",
+			"var localize = nls.loadMessageBundle(require('path').join(__dirname, 'foo.js'));",
 			"localize(0, null, 'Hello', 'World');"
 		];
 		assert.strictEqual(result.contents, expected.join('\n'));

--- a/src/vscl.ts
+++ b/src/vscl.ts
@@ -27,11 +27,16 @@ let argv = yargs
 		describe: 'The root directory of the sources. Only honored when outDir is set.',
 		demand: false
 	})
+	.option('keepFilenames', {
+		describe: 'Inlines filenames when making localization calls. Only honored when rootDir is set.',
+		demand: false
+	})
 	.argv;
 
 let hasError: boolean = false;
 let outDir = argv.outDir ? path.resolve(argv.outDir) : null;
 let rootDir = argv.rootDir ? path.resolve(argv.rootDir) : null;
+let keepFilenames = Boolean(argv.keepFilenames);
 
 argv._.forEach(element => {
 	glob(element, (err, matches) => {
@@ -67,7 +72,10 @@ argv._.forEach(element => {
 					sourceMapContent = fs.readFileSync(resolvedSourceMapFile, 'utf8');
 				}
 			}
-			let result = processFile(contents, sourceMapContent);
+
+			let relativeFilename = keepFilenames && rootDir ? path.relative(rootDir, resolvedFile) : undefined;
+			let result = processFile(contents, relativeFilename, sourceMapContent);
+			
 			if (result.errors && result.errors.length > 0) {
 				result.errors.forEach(error => console.error(`${file}${error}`));
 				hasError = true;


### PR DESCRIPTION
Because bundlers, like webpack or rollup, put everything into a single lookup cannot be make using `__filename` anymore. This PR adds an option to keep the original filename when rewriting localise-calls. It uses a `join(__dirname, 'originalName.js')`-trick so that the els-metadata files can be found and so that the original name can used to look up the actual strings. 