### PR TITLE
Add support for hints in `package.nls.json`

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -588,7 +588,7 @@ export function createXlfFiles(projectName: string, extensionName: string): Thro
 						comment: value.comment
 					};
 				} else {
-					return `Unknown message for key: ${keys[i]}`;
+					messages.push(`Unknown message for key: ${keys[i]}`);
 				}
 			}
 			getXlf().addFile('package', keys, messages);


### PR DESCRIPTION
Addresses: https://github.com/microsoft/vscode-nls-dev/issues/32

Hints can be added to `package.nls.json` in the following format:

```
    "key": {
        "message": "<message>",
        "comment": [ "<hint1>", "<hint2>" ]
    },
```

There was already support in place for objects with a `message` field in `package.nls.json`, so this should not break compatibility with that.

There was existing support in `addFile()` for a `comment` array to be pass in via the `key` (though, using `message` would have made more sense to me).  This looks to be used by existing support for hints in calls to `localize()`.  I updated `createXlfFiles()` to leverage this existing support to store hints/comments from `package.nls.json` in the `key`. 
 I also updated `addFile()` to use only the `key` string value itself for comparisons with `existingKeys`.