### PR TITLE
Allow overriding basedir to fix web

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -347,7 +347,7 @@ class TextModel {
 	}
 }
 
-function analyze(contents: string, relativeFilename: string | undefined, options: ts.CompilerOptions = {}): AnalysisResult {
+function analyze(contents: string, relativeFilename?: string, baseDir?: string, options: ts.CompilerOptions = {}): AnalysisResult {
 
 	const vscodeRegExp = /^\s*(["'])vscode-nls\1\s*$/;
 
@@ -553,9 +553,10 @@ function analyze(contents: string, relativeFilename: string | undefined, options
 	loadCalls.reduce((memo, loadCall) => {
 		if (loadCall.arguments.length === 0) {
 			const args = loadCall.arguments;
+			const dir = baseDir ? JSON.stringify(baseDir) : '__dirname';
 			patches.push({
 				span: { start: ts.getLineAndCharacterOfPosition(sourceFile, args.pos), end: ts.getLineAndCharacterOfPosition(sourceFile, args.end) },
-				content: relativeFilename ? `require('path').join(__dirname, '${relativeFilename.replace(/\\/g, '\\\\')}')` : '__filename',
+				content: relativeFilename ? `require('path').join(${dir}, '${relativeFilename.replace(/\\/g, '\\\\')}')` : '__filename',
 			});
 		}
 		return memo;
@@ -640,9 +641,8 @@ function analyze(contents: string, relativeFilename: string | undefined, options
 	};
 }
 
-export function processFile(contents: string, relativeFileName: string | undefined, sourceMap?: string | RawSourceMap): { contents: string | undefined, sourceMap: string | undefined, bundle: JavaScriptMessageBundle | undefined, errors: string[] } {
-
-	const analysisResult = analyze(contents, relativeFileName);
+export function processFile(contents: string, relativeFileName?: string, baseDir?: string, sourceMap?: string | RawSourceMap): { contents?: string, sourceMap?: string, bundle?: JavaScriptMessageBundle, errors: string[] } {
+	const analysisResult = analyze(contents, relativeFileName, baseDir);
 	if (analysisResult.patches.length === 0) {
 		return {
 			contents: undefined,

--- a/src/main.ts
+++ b/src/main.ts
@@ -40,7 +40,7 @@ export function rewriteLocalizeCalls(): ThroughStream {
 			const content = buffer.toString('utf8');
 			const sourceMap = file.sourceMap;
 
-			const result = processFile(content, undefined, sourceMap);
+			const result = processFile(content, undefined, undefined, sourceMap);
 			let messagesFile: File | undefined;
 			let metaDataFile: File | undefined;
 			if (result.errors && result.errors.length > 0) {
@@ -89,7 +89,7 @@ export function createMetaDataFiles(): ThroughStream {
 				return;
 			}
 
-			let result = processFile(file.contents.toString('utf8'), undefined, undefined);
+			let result = processFile(file.contents.toString('utf8'));
 			if (result.errors && result.errors.length > 0) {
 				result.errors.forEach(error => console.error(`${file.relative}${error}`));
 				this.emit('error', `Failed to rewrite file: ${file.path}`);

--- a/src/tests/analyze.tests.ts
+++ b/src/tests/analyze.tests.ts
@@ -23,7 +23,7 @@ suite('Localize', () => {
 			'localize(0, null, \'Hello\', \'World\');',
 			'//# sourceMappingURL=test.js.map'
 		];
-		let result = nlsDev.processFile(code.join('\r\n'), undefined, sourceMap);
+		let result = nlsDev.processFile(code.join('\r\n'), undefined, undefined, sourceMap);
 
 		assert.strictEqual(result.contents, expected.join('\r\n'));
 		assert.strictEqual(result.sourceMap, '{"version":3,"sources":["test.ts"],"names":[],"mappings":"AAAA,IAAY,GAAG,WAAM,YAAY,CAAC,CAAA;AAClC,IAAI,QAAQ,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,MAAM,EAAE,OAAO,EAAE,KAAK,EAAE,IAAI,EAAE,CAAC,YAAE,CAAC;AAC9D,QAAQ,CAAC,aAAyB,EAAE,OAAO,CAAC,CAAC","sourceRoot":""}');
@@ -53,7 +53,7 @@ suite('Localize', () => {
 			'localize(0, null, \'Hello\', \'World\');',
 			'//# sourceMappingURL=test.js.map'
 		];
-		let result = nlsDev.processFile(code.join('\r\n'), undefined, sourceMap);
+		let result = nlsDev.processFile(code.join('\r\n'), undefined, undefined, sourceMap);
 		assert.strictEqual(result.contents, expected.join('\r\n'));
 		assert.strictEqual(result.sourceMap, '{"version":3,"sources":["test.ts"],"names":[],"mappings":"AAAA,IAAY,GAAG,WAAM,YAAY,CAAC,CAAA;AAClC,IAAI,QAAQ,GAAG,GAAG,CAAC,MAAM,CAAC,EAAE,MAAM,EAAE,OAAO,EAAE,KAAK,EAAE,IAAI,EAAE,CAAC,YAAE,CAAC;AAC9D,QAAQ,CAAC,CAGR,EAAE,IAAS,EAAE,OAAO,EAAE,OAAO,CAAC,CAAC","sourceRoot":""}');
 		assert.deepStrictEqual(result.bundle, {
@@ -143,6 +143,20 @@ suite('Localize', () => {
 		assert.strictEqual(result.contents, expected.join('\n'));
 	});
 
+	test('allows overriding base directory', ()	=> {
+		let code: string[] = [
+			'const nls = __importStar(require(\'vscode-nls\'))',
+			'var localize = nls.loadMessageBundle();',
+			'localize(\'keyOne\', \'{0} {1}\', \'Hello\', \'World\');'
+		];
+		let result = nlsDev.processFile(code.join('\n'), 'foo.js', '/');
+		let expected: string[] = [
+			'const nls = __importStar(require(\'vscode-nls\'))',
+			'var localize = nls.loadMessageBundle(require(\'path\').join("/", \'foo.js\'));',
+			'localize(0, null, \'Hello\', \'World\');'
+		];
+		assert.strictEqual(result.contents, expected.join('\n'));
+	});
 
 	test('https://github.com/Microsoft/vscode/issues/56792', () => {
 		let code: string[] = [

--- a/src/vscl.ts
+++ b/src/vscl.ts
@@ -80,7 +80,7 @@ argv._.forEach(element => {
 			}
 
 			const relativeFilename = keepFilenames && rootDir ? path.relative(rootDir, resolvedFile) : undefined;
-			const result = processFile(contents, relativeFilename, sourceMapContent);
+			const result = processFile(contents, relativeFilename, undefined, sourceMapContent);
 
 			if (result.errors && result.errors.length > 0) {
 				result.errors.forEach(error => console.error(`${file}${error}`));

--- a/src/webpack-loader.ts
+++ b/src/webpack-loader.ts
@@ -17,7 +17,11 @@ module.exports = function (this: any, content: any, map: any, meta: any) {
 
 	const callback = this.async();
 	const relativePath = relative(this.query.base, this.resourcePath);
-	const result = processFile(content, relativePath, map);
+	const result = processFile(
+		content,
+		relativePath,
+		this.target === 'webworker' || this.target === 'web' ? '/' : undefined,
+		map);
 
 	if (result.errors && result.errors.length > 0) {
 		// error


### PR DESCRIPTION
The problem was that this line that included `__dirname` was always being injected even for web which caused failures.

So this changes allows the ability to override what gets set there. So the webpack loader will see that it's building a web extension and inject `/` instead... which will get removed here:
https://github.com/microsoft/vscode-nls/blob/main/src/browser/main.ts#L43-L45

