### PR TITLE
Add fileExists and readFile for SingleFileServiceHost

### DIFF
--- a/src/lib.ts
+++ b/src/lib.ts
@@ -31,6 +31,8 @@ class SingleFileServiceHost implements ts.LanguageServiceHost {
 	getScriptSnapshot = (name: string) => name === this.filename ? this.file : this.lib;
 	getCurrentDirectory = () => '';
 	getDefaultLibFileName = () => 'lib.d.ts';
+	fileExists = () => true;
+	readFile = () => '';
 }
 
 


### PR DESCRIPTION
Fix `TypeError: host.fileExists is not a function` when using vscode-nls-dev with typescript 4.8. 

Issue: #42